### PR TITLE
Fix pod name

### DIFF
--- a/docs/4-rhaiis/notebooks/1-inference-with-vllm.ipynb
+++ b/docs/4-rhaiis/notebooks/1-inference-with-vllm.ipynb
@@ -462,7 +462,7 @@
     }
    ],
    "source": [
-    "!oc exec vllm-demo-0 -- nvidia-smi"
+    "!oc exec vllm-0 -- nvidia-smi"
    ]
   },
   {


### PR DESCRIPTION
Pod name doesn't match with workbench name. vllm vs vllm-demo. 